### PR TITLE
V2.28 warnings fix

### DIFF
--- a/contrib/slime-repl.el
+++ b/contrib/slime-repl.el
@@ -1728,10 +1728,8 @@ expansion will be added to the REPL's history.)"
 
 (defun slime-repl-event-hook-function (event)
   (slime-dcase event
-    ((:write-string output &optional target thread)
+    ((:write-string output &optional target)
      (slime-write-string output target)
-     (when thread
-       (slime-send `(:write-done ,thread)))
      t)
     ((:read-string thread tag)
      (cl-assert thread)

--- a/contrib/swank-repl.lisp
+++ b/contrib/swank-repl.lisp
@@ -122,11 +122,7 @@ DEDICATED-OUTPUT INPUT OUTPUT IO REPL-RESULTS"
   "Create function to send user output to Emacs."
   (lambda (string)
     (with-connection (connection)
-      (send-to-emacs `(:write-string ,string nil ,(current-thread-id)))
-      ;; Wait for Emacs to finish writing, otherwise on continuous
-      ;; output its input buffer will fill up and nothing else will be
-      ;; processed, most importantly an interrupt-thread request.
-      (wait-for-event `(:write-done)))))
+      (send-to-emacs `(:write-string ,string)))))
 
 (defun open-dedicated-output-stream (connection coding-system)
   "Open a dedicated output connection to the Emacs on SOCKET-IO.

--- a/swank.lisp
+++ b/swank.lisp
@@ -1010,8 +1010,7 @@ The processing is done in the extent of the toplevel restart."
           &rest _)
          (declare (ignore _))
          (encode-message event (current-socket-io)))
-        (((:emacs-pong :emacs-return :emacs-return-string :ed-rpc-forbidden
-           :write-done)
+        (((:emacs-pong :emacs-return :emacs-return-string :ed-rpc-forbidden)
           thread-id &rest args)
          (send-event (find-thread thread-id) (cons (car event) args)))
         ((:emacs-channel-send channel-id msg)

--- a/swank/gray.lisp
+++ b/swank/gray.lisp
@@ -39,9 +39,11 @@
 
 (in-package swank/gray)
 
+(defconstant +string-maximum+ 64000)
+
 (defclass slime-output-stream (fundamental-character-output-stream)
   ((output-fn :initarg :output-fn)
-   (buffer :initform (make-string 64000))
+   (buffer :initform (make-string +string-maximum+))
    (fill-pointer :initform 0)
    (column :initform 0)
    (lock :initform (make-lock :name "buffer write lock"))


### PR DESCRIPTION
Reverts the commit that caused https://github.com/vlime/vlime/issues/75

It's also pending upstream.